### PR TITLE
add login by accessor

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -24,8 +24,8 @@ const (
 	configPath = "config"
 	rolePath   = "role"
 
-	tlsUpdateTicker    = time.Second * 30
-	tokenLookupTimeout = time.Second * 30
+	tlsUpdateTicker = time.Second * 30
+	requestTimeout  = time.Second * 30
 )
 
 var (

--- a/path_role.go
+++ b/path_role.go
@@ -106,6 +106,12 @@ func (b *crossVaultAuthBackend) pathRole() *framework.Path {
 				Description: `Flag defines whether provided entity metadata must strictly match with 
 metadata stored for target entity in target Vault cluster`,
 			},
+			"token_ttl": {
+				Type: framework.TypeDurationSecond,
+			},
+			"token_policies": {
+				Type: framework.TypeCommaStringSlice,
+			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.CreateOperation: &framework.PathOperation{


### PR DESCRIPTION
- `token` parameter for `auth/{mount}/login` path renamed to `secret`
- added `accessor` boolean parameter, so token accessor can be used for login instead of token